### PR TITLE
收录 EVORA 脉流中转科技

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@
 - https://deepkey.top/ - deepkey.top，专注提供 Claude Code、Codex、Gemini API 密钥，99.9% 可用性，高性价比，数据安全，原版无降智
 - https://api.code-relay.com/ - Code Router，统一的大模型接口网关，兼容 Claude、OpenAI 等主流 AI 编程服务，更好的价格与稳定性，国内备案企业运营
 - https://letaicode.cn/ - LetAiCode，集成 Claude Code、Gemini Pro、OpenAI Codex，官方直连无降智，按量计费明码标价，支持企业开票，VIP 专属售后群
-- https://code.ai80.vip/home - Code80·AI 编
-程巴士，纯血订阅账号转发（Claude Max / ChatGPT Plus / Google），99.9% 可用率，完整支持 Extended Thinking，接入 Claude、GPT、Gemini，包月约 ¥2/$
+- https://code.ai80.vip/home - Code80·AI 编程巴士，纯血订阅账号转发（Claude Max / ChatGPT Plus / Google），99.9% 可用率，完整支持 Extended Thinking，接入 Claude、GPT、Gemini，包月约 ¥2/$
 - https://api.xnark.com/home - 小诺方舟 XNARK，企业级 Model Gateway，支持 Claude Code / OpenCode，协议自动转换，聚合 Claude、GPT-5.4、GLM-5、Kimi 2.5 等模型，<50ms 平均延迟
 - https://sub.tisoz.com/home - 小肩膀 AI，订阅转 API 平台，支持 Claude、GPT、Gemini、Antigravity，一键接入，智能调度多账号，按量计费
 - https://codex.hualong.site/ - 华龙中转站，纯血 Pro 20x 号池，订阅转 API，支持 Claude、GPT、Gemini，包月套餐，稳定优先绝不掺假
@@ -51,6 +50,7 @@
 - https://mytoken.top/ - 全球Token站，77+ AI 模型统一 API 接入，低延迟优化路由，企业级安全加密，按量计费透明定价，多节点全球加速
 - https://api.mooko.ai/ 木瓜AI-大模型中转平台 推荐一个 倍率0.01，等于1分=1刀，不介意的老铁用的邀请码吧 https://api.mooko.ai/register?aff=hU6L  
 - https://vip.voycloud.com/ VoycloudAi-大模型中转平台，提供整合工具，计费透明，多种模式链接  
+- https://evora-token-reseller.vercel.app/ - EVORA 脉流中转科技，提供 OpenAI 兼容接口，支持 Codex / CC Switch 等工具接入，按量能量计费，用量与扣费记录可查。
 --- 
 
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@
 - https://deepkey.top/ - deepkey.top，专注提供 Claude Code、Codex、Gemini API 密钥，99.9% 可用性，高性价比，数据安全，原版无降智
 - https://api.code-relay.com/ - Code Router，统一的大模型接口网关，兼容 Claude、OpenAI 等主流 AI 编程服务，更好的价格与稳定性，国内备案企业运营
 - https://letaicode.cn/ - LetAiCode，集成 Claude Code、Gemini Pro、OpenAI Codex，官方直连无降智，按量计费明码标价，支持企业开票，VIP 专属售后群
-- https://code.ai80.vip/home - Code80·AI 编程巴士，纯血订阅账号转发（Claude Max / ChatGPT Plus / Google），99.9% 可用率，完整支持 Extended Thinking，接入 Claude、GPT、Gemini，包月约 ¥2/$
+- https://code.ai80.vip/home - Code80·AI 编
+程巴士，纯血订阅账号转发（Claude Max / ChatGPT Plus / Google），99.9% 可用率，完整支持 Extended Thinking，接入 Claude、GPT、Gemini，包月约 ¥2/$
 - https://api.xnark.com/home - 小诺方舟 XNARK，企业级 Model Gateway，支持 Claude Code / OpenCode，协议自动转换，聚合 Claude、GPT-5.4、GLM-5、Kimi 2.5 等模型，<50ms 平均延迟
 - https://sub.tisoz.com/home - 小肩膀 AI，订阅转 API 平台，支持 Claude、GPT、Gemini、Antigravity，一键接入，智能调度多账号，按量计费
 - https://codex.hualong.site/ - 华龙中转站，纯血 Pro 20x 号池，订阅转 API，支持 Claude、GPT、Gemini，包月套餐，稳定优先绝不掺假


### PR DESCRIPTION
## 站点说明

新增 **EVORA 脉流中转科技**：

- 官网：https://evora-token-reseller.vercel.app/
- 提供 OpenAI 兼容接口
- 支持 Codex / CC Switch 等工具接入
- 按量使用能量计费，用量与扣费记录可查

网站链接已检查，可以正常访问。